### PR TITLE
Feature/filter fields

### DIFF
--- a/src/esTest.php
+++ b/src/esTest.php
@@ -1,31 +1,29 @@
 <?php
 use PHPUnit\Framework\TestCase;
+use Boolbuilder\ES;
 
 final class EsTest extends TestCase
 {
     public function testArrayArgToGetArrayValueIsSelf()
     {
-        $this->assertEquals(\Boolbuilder\ES\getArrayValue([1, 2]), [1, 2]);
+        $this->assertEquals(ES\getArrayValue([1, 2]), [1, 2]);
     }
 
     public function testStringArgToGetArrayValueIsArray()
     {
-        $this->assertEquals(\Boolbuilder\ES\getArrayValue('1, 2'), ['1', '2']);
+        $this->assertEquals(ES\getArrayValue('1, 2'), ['1', '2']);
     }
 
     public function testNonArrayStringArgToGetArrayValueThrows()
     {
         $this->expectException(\Exception::class);
-        \Boolbuilder\ES\getArrayValue(true);
+        ES\getArrayValue(true);
     }
 
     public function testIsNullOperatorArgToGetFragmentReturnsExists()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getFragment([
-                'field' => 'name',
-                'operator' => 'is_null'
-            ]),
+            ES\getFragment(['field' => 'name', 'operator' => 'is_null']),
             ['exists' => ['field' => 'name']]
         );
     }
@@ -33,7 +31,7 @@ final class EsTest extends TestCase
     public function testProximityOperatorArgToGetFragmentReturnsStandard()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getFragment([
+            ES\getFragment([
                 'field' => 'name',
                 'operator' => 'proximity',
                 'value' => ['a', '2']
@@ -45,25 +43,20 @@ final class EsTest extends TestCase
     public function testDefaultCondAndNegativeToGetClauseReturnsMustNot()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getClause([], ['operator' => 'not_equal']),
+            ES\getClause([], ['operator' => 'not_equal']),
             'must_not'
         );
     }
 
     public function testDefaultCondAndNonNegativeToGetClauseReturnsMust()
     {
-        $this->assertEquals(
-            \Boolbuilder\ES\getClause([], ['operator' => 'equal']),
-            'must'
-        );
+        $this->assertEquals(ES\getClause([], ['operator' => 'equal']), 'must');
     }
 
     public function testOrCondAndAnythingToGetClauseReturnsMust()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getClause(['condition' => 'OR'], [
-                'operator' => 'not_equal'
-            ]),
+            ES\getClause(['condition' => 'OR'], ['operator' => 'not_equal']),
             'should'
         );
     }
@@ -71,23 +64,18 @@ final class EsTest extends TestCase
     public function testUnhandledCondToGetClauseThrows()
     {
         $this->expectException(\Exception::class);
-        \Boolbuilder\ES\getClause(['condition' => 'xor'], [
-            'operator' => 'not_equal'
-        ]);
+        ES\getClause(['condition' => 'xor'], ['operator' => 'not_equal']);
     }
 
     public function testWildcardSplatCharToGetOperatorIsWildcard()
     {
-        $this->assertEquals(
-            \Boolbuilder\ES\getOperator(['value' => 'hello*']),
-            'wildcard'
-        );
+        $this->assertEquals(ES\getOperator(['value' => 'hello*']), 'wildcard');
     }
 
     public function testWildcardQuestionCharToGetOperatorIsWildcard()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getOperator(['value' => 'hello world?']),
+            ES\getOperator(['value' => 'hello world?']),
             'wildcard'
         );
     }
@@ -95,10 +83,7 @@ final class EsTest extends TestCase
     public function testContainsToGetOperatorIsMatch()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getOperator([
-                'operator' => 'contains',
-                'value' => ''
-            ]),
+            ES\getOperator(['operator' => 'contains', 'value' => '']),
             'match'
         );
     }
@@ -106,10 +91,7 @@ final class EsTest extends TestCase
     public function testUnknownToGetOperatorIsRange()
     {
         $this->assertEquals(
-            \Boolbuilder\ES\getOperator([
-                'operator' => '>>>',
-                'value' => 'hello world'
-            ]),
+            ES\getOperator(['operator' => '>>>', 'value' => 'hello world']),
             'range'
         );
     }
@@ -117,8 +99,8 @@ final class EsTest extends TestCase
     public function testBetweenToGetValueIsGteLteArray()
     {
         $rule = ['operator' => 'between', 'value' => ['1', '2']];
-        $operator = \Boolbuilder\ES\getOperator($rule);
-        $this->assertEquals(\Boolbuilder\ES\getValue($rule, $operator), [
+        $operator = ES\getOperator($rule);
+        $this->assertEquals(ES\getValue($rule, $operator), [
             'gte' => '1',
             'lte' => '2'
         ]);
@@ -128,23 +110,17 @@ final class EsTest extends TestCase
     {
         $this->expectException(\Exception::class);
         $rule = ['operator' => '<>', 'value' => ['1', '2']];
-        $operator = \Boolbuilder\ES\getOperator($rule);
-        \Boolbuilder\ES\getValue($rule, $operator);
+        $operator = ES\getOperator($rule);
+        ES\getValue($rule, $operator);
     }
 
     public function testIsNullToIsNegativeOperatorIsTrue()
     {
-        $this->assertEquals(
-            \Boolbuilder\ES\isNegativeOperator('is_null'),
-            true
-        );
+        $this->assertEquals(ES\isNegativeOperator('is_null'), true);
     }
 
     public function testGreaterToIsNegativeOperatorIsFalse()
     {
-        $this->assertEquals(
-            \Boolbuilder\ES\isNegativeOperator('greater'),
-            false
-        );
+        $this->assertEquals(ES\isNegativeOperator('greater'), false);
     }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -68,16 +68,7 @@ function transformRule($group, $rule, $filters, $options)
         return transform($rule, $filters, $options);
     }
 
-    if (
-        (
-            isset($options['filterFields']) &&
-            in_array($rule['field'], $options['filterFields'], true)
-        ) ||
-        (
-            isset($options['filterOperators']) &&
-            in_array($rule['operator'], $options['filterOperators'], true)
-        )
-    ) {
+    if (isRuleExcluded($rule, $options)) {
         return null;
     }
 
@@ -91,4 +82,23 @@ function transformRule($group, $rule, $filters, $options)
     }
 
     return $fragment;
+}
+
+function isRuleExcluded($rule, $options)
+{
+    if (
+        isset($options['filterFields']) &&
+        in_array($rule['field'], $options['filterFields'], true)
+    ) {
+        return true;
+    }
+
+    if (
+        isset($options['filterOperators']) &&
+        in_array($rule['operator'], $options['filterOperators'], true)
+    ) {
+        return true;
+    }
+
+    return false;
 }

--- a/src/index.php
+++ b/src/index.php
@@ -69,8 +69,14 @@ function transformRule($group, $rule, $filters, $options)
     }
 
     if (
-        isset($options['filterFields']) &&
-        in_array($rule['field'], $options['filterFields'], true)
+        (
+            isset($options['filterFields']) &&
+            in_array($rule['field'], $options['filterFields'], true)
+        ) ||
+        (
+            isset($options['filterOperators']) &&
+            in_array($rule['operator'], $options['filterOperators'], true)
+        )
     ) {
         return null;
     }

--- a/src/index.php
+++ b/src/index.php
@@ -87,6 +87,13 @@ function transformRule($group, $rule, $filters, $options)
 function isRuleExcluded($rule, $options)
 {
     if (
+        isset($options['onlyFields']) &&
+        !in_array($rule['field'], $options['onlyFields'], true)
+    ) {
+        return true;
+    }
+
+    if (
         isset($options['filterFields']) &&
         in_array($rule['field'], $options['filterFields'], true)
     ) {

--- a/src/index.php
+++ b/src/index.php
@@ -29,8 +29,7 @@ function transform($group, $filters = [])
     }
 
     return [
-        'bool' => call_user_func(
-            __NAMESPACE__ . '\\transformGroupDefaultFilter',
+        'bool' => transformGroupDefaultFilter(
             $group,
             $rules,
             $filters,

--- a/src/index.php
+++ b/src/index.php
@@ -76,7 +76,7 @@ function transformRule($group, $rule, $filters)
     $rules = isset($rule['rules']) ? $rule['rules'] : [];
 
     if (count($rules) > 0) {
-        return call_user_func(__NAMESPACE__ . '\\transform', $rule, $filters);
+        return transform($rule, $filters);
     }
 
     $fragment = \Boolbuilder\ES\getFragment($rule);

--- a/src/index.php
+++ b/src/index.php
@@ -40,23 +40,20 @@ function transform($group, $filters = [])
 
 function transformGroupPostFilter($group, $rules, $filters)
 {
-    $clausesAndFragments = array_map(function ($rule) use ($group, $filters) {
-        return [
-            'clause' => \Boolbuilder\ES\getClause($group, $rule),
-            'fragment' => transformRule($group, $rule, $filters)
-        ];
-    }, $rules);
+    return array_reduce(
+        $rules,
+        function ($carry, $rule) use ($group, $filters) {
+            $clause = \Boolbuilder\ES\getClause($group, $rule);
+            $fragment = transformRule($group, $rule, $filters);
 
-    return array_reduce($clausesAndFragments, function ($carry, $data) {
-        $clause = $data['clause'];
-        $fragment = $data['fragment'];
+            $existingFragments = isset($carry[$clause]) ? $carry[$clause] : [];
 
-        $existingFragments = isset($carry[$clause]) ? $carry[$clause] : [];
-
-        return array_merge($carry, [
-            $clause => array_merge($existingFragments, [$fragment])
-        ]);
-    }, []);
+            return array_merge($carry, [
+                $clause => array_merge($existingFragments, [$fragment])
+            ]);
+        },
+        []
+    );
 }
 
 function transformGroupDefaultFilter(

--- a/src/index.php
+++ b/src/index.php
@@ -1,6 +1,8 @@
 <?php
 namespace Boolbuilder;
 
+use Boolbuilder\ES;
+
 function transform($group, $filters = [])
 {
     if (!$group) {
@@ -43,7 +45,7 @@ function transformGroupPostFilter($group, $rules, $filters)
     return array_reduce(
         $rules,
         function ($carry, $rule) use ($group, $filters) {
-            $clause = \Boolbuilder\ES\getClause($group, $rule);
+            $clause = ES\getClause($group, $rule);
             $fragment = transformRule($group, $rule, $filters);
 
             $existingFragments = isset($carry[$clause]) ? $carry[$clause] : [];
@@ -76,14 +78,11 @@ function transformRule($group, $rule, $filters)
         return transform($rule, $filters);
     }
 
-    $fragment = \Boolbuilder\ES\getFragment($rule);
+    $fragment = ES\getFragment($rule);
 
     // this is a corner case, when we have an "or" group and a negative operator,
     // we express this with a sub boolean query and must_not
-    if (
-        strtoupper($condition) === 'OR' &&
-        \Boolbuilder\ES\isNegativeOperator($operator)
-    ) {
+    if (strtoupper($condition) === 'OR' && ES\isNegativeOperator($operator)) {
 
         return ['bool' => ['must_not' => [$fragment]]];
     }

--- a/src/index.php
+++ b/src/index.php
@@ -46,6 +46,10 @@ function transformGroupPostFilter($group, $rules, $filters, $options)
         $clause = ES\getClause($group, $rule);
         $fragment = transformRule($group, $rule, $filters, $options);
 
+        if ($fragment === null) {
+            return $carry;
+        }
+
         $existingFragments = isset($carry[$clause]) ? $carry[$clause] : [];
 
         return array_merge($carry, [
@@ -62,6 +66,13 @@ function transformRule($group, $rule, $filters, $options)
 
     if (count($rules) > 0) {
         return transform($rule, $filters, $options);
+    }
+
+    if (
+        isset($options['filterFields']) &&
+        in_array($rule['field'], $options['filterFields'], true)
+    ) {
+        return null;
     }
 
     $fragment = ES\getFragment($rule);

--- a/src/index.php
+++ b/src/index.php
@@ -16,10 +16,10 @@ function transform($group, $filters = [])
         return [];
     }
 
-    $postFilterUserFuncName = __NAMESPACE__ . '\\transformGroupPostFilter';
-
     if (isset($filters[$QB])) {
         $userProvidedFilter = $filters[$QB];
+        $postFilterUserFuncName = __NAMESPACE__ . '\\transformGroupPostFilter';
+
         return [
             'bool' => $userProvidedFilter(
                 $group,
@@ -30,14 +30,7 @@ function transform($group, $filters = [])
         ];
     }
 
-    return [
-        'bool' => transformGroupDefaultFilter(
-            $group,
-            $rules,
-            $filters,
-            $postFilterUserFuncName
-        )
-    ];
+    return ['bool' => transformGroupPostFilter($group, $rules, $filters)];
 }
 
 function transformGroupPostFilter($group, $rules, $filters)
@@ -56,16 +49,6 @@ function transformGroupPostFilter($group, $rules, $filters)
         },
         []
     );
-}
-
-function transformGroupDefaultFilter(
-    $group,
-    $rules,
-    $filters,
-    $postFilterUserFuncName
-)
-{
-    return call_user_func($postFilterUserFuncName, $group, $rules, $filters);
 }
 
 function transformRule($group, $rule, $filters)

--- a/src/indexTest.php
+++ b/src/indexTest.php
@@ -282,4 +282,96 @@ final class IndexTest extends TestCase
 
         $this->assertEquals($result, $expected);
     }
+
+    public function testQBData6()
+    {
+        $QBdata = [
+            'condition' => 'AND',
+            'rules' => [
+                [
+                    'id' => 'name',
+                    'field' => 'name',
+                    'type' => 'string',
+                    'input' => 'text',
+                    'operator' => 'contains',
+                    'value' => '123'
+                ],
+                [
+                    'QB' => 'book',
+                    'condition' => 'or',
+                    'rules' => [
+                        [
+                            'id' => 'misc',
+                            'field' => 'misc',
+                            'type' => 'string',
+                            'input' => 'text',
+                            'operator' => 'is_null',
+                            'value' => null
+                        ],
+                        [
+                            'id' => 'type',
+                            'field' => 'type',
+                            'type' => 'string',
+                            'input' => 'checkbox',
+                            'operator' => 'in',
+                            'value' => ['book']
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $filters = [
+            'book' => function (
+                $group,
+                $rules,
+                $filters,
+                $options,
+                $postFilterUserFuncName
+            ) {
+                return [
+                    'must' => [
+                        ['terms' => ['_type' => ['book']]],
+                        [
+                            'bool' => call_user_func(
+                                $postFilterUserFuncName,
+                                $group,
+                                $rules,
+                                $filters,
+                                $options
+                            )
+                        ]
+                    ]
+                ];
+            }
+        ];
+
+        $options = ['filterFields' => ['misc']];
+
+        $result = \Boolbuilder\transform($QBdata, $filters, $options);
+
+        $expected = [
+            'bool' => [
+                'must' => [
+                    ['match' => ['name' => '123']],
+                    [
+                        'bool' => [
+                            'must' => [
+                                ['terms' => ['_type' => ['book']]],
+                                [
+                                    'bool' => [
+                                        'should' => [
+                                            ['terms' => ['type' => ['book']]]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($result, $expected);
+    }
 }

--- a/src/indexTest.php
+++ b/src/indexTest.php
@@ -374,4 +374,96 @@ final class IndexTest extends TestCase
 
         $this->assertEquals($result, $expected);
     }
+
+    public function testQBData7()
+    {
+        $QBdata = [
+            'condition' => 'AND',
+            'rules' => [
+                [
+                    'id' => 'name',
+                    'field' => 'name',
+                    'type' => 'string',
+                    'input' => 'text',
+                    'operator' => 'contains',
+                    'value' => '123'
+                ],
+                [
+                    'QB' => 'book',
+                    'condition' => 'or',
+                    'rules' => [
+                        [
+                            'id' => 'misc',
+                            'field' => 'misc',
+                            'type' => 'string',
+                            'input' => 'text',
+                            'operator' => 'is_null',
+                            'value' => null
+                        ],
+                        [
+                            'id' => 'type',
+                            'field' => 'type',
+                            'type' => 'string',
+                            'input' => 'checkbox',
+                            'operator' => 'in',
+                            'value' => ['book']
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $filters = [
+            'book' => function (
+                $group,
+                $rules,
+                $filters,
+                $options,
+                $postFilterUserFuncName
+            ) {
+                return [
+                    'must' => [
+                        ['terms' => ['_type' => ['book']]],
+                        [
+                            'bool' => call_user_func(
+                                $postFilterUserFuncName,
+                                $group,
+                                $rules,
+                                $filters,
+                                $options
+                            )
+                        ]
+                    ]
+                ];
+            }
+        ];
+
+        $options = ['filterOperators' => ['is_not_null', 'is_null']];
+
+        $result = Boolbuilder\transform($QBdata, $filters, $options);
+
+        $expected = [
+            'bool' => [
+                'must' => [
+                    ['match' => ['name' => '123']],
+                    [
+                        'bool' => [
+                            'must' => [
+                                ['terms' => ['_type' => ['book']]],
+                                [
+                                    'bool' => [
+                                        'should' => [
+                                            ['terms' => ['type' => ['book']]]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($result, $expected);
+    }
 }

--- a/src/indexTest.php
+++ b/src/indexTest.php
@@ -540,6 +540,7 @@ final class IndexTest extends TestCase
                     [
                         'bool' => [
                             'must' => [
+                                ['terms' => ['_type' => ['book']]],
                                 [
                                     'bool' => [
                                         'should' => [

--- a/src/indexTest.php
+++ b/src/indexTest.php
@@ -225,6 +225,7 @@ final class IndexTest extends TestCase
                 $group,
                 $rules,
                 $filters,
+                $options,
                 $postFilterUserFuncName
             ) {
                 return [
@@ -235,7 +236,8 @@ final class IndexTest extends TestCase
                                 $postFilterUserFuncName,
                                 $group,
                                 $rules,
-                                $filters
+                                $filters,
+                                $options
                             )
                         ]
                     ]

--- a/src/indexTest.php
+++ b/src/indexTest.php
@@ -19,7 +19,7 @@ final class IndexTest extends TestCase
             ]
         ];
 
-        $result = \Boolbuilder\transform($QBdata);
+        $result = Boolbuilder\transform($QBdata);
 
         $expected = ['bool' => ['must' => [['match' => ['name' => '123']]]]];
 
@@ -42,7 +42,7 @@ final class IndexTest extends TestCase
             ]
         ];
 
-        $result = \Boolbuilder\transform($QBdata);
+        $result = Boolbuilder\transform($QBdata);
 
         $expected = ['bool' => ['should' => [['match' => ['name' => '123']]]]];
 
@@ -86,7 +86,7 @@ final class IndexTest extends TestCase
             ]
         ];
 
-        $result = \Boolbuilder\transform($QBdata);
+        $result = Boolbuilder\transform($QBdata);
 
         $expected = [
             'bool' => [
@@ -111,7 +111,7 @@ final class IndexTest extends TestCase
     {
         $QBdata = [];
 
-        $result = \Boolbuilder\transform($QBdata);
+        $result = Boolbuilder\transform($QBdata);
 
         $expected = [];
 
@@ -155,7 +155,7 @@ final class IndexTest extends TestCase
             ]
         ];
 
-        $result = \Boolbuilder\transform($QBdata);
+        $result = Boolbuilder\transform($QBdata);
 
         $expected = [
             'bool' => [
@@ -245,7 +245,7 @@ final class IndexTest extends TestCase
             }
         ];
 
-        $result = \Boolbuilder\transform($QBdata, $filters);
+        $result = Boolbuilder\transform($QBdata, $filters);
 
         $expected = [
             'bool' => [
@@ -348,7 +348,7 @@ final class IndexTest extends TestCase
 
         $options = ['filterFields' => ['misc']];
 
-        $result = \Boolbuilder\transform($QBdata, $filters, $options);
+        $result = Boolbuilder\transform($QBdata, $filters, $options);
 
         $expected = [
             'bool' => [

--- a/src/indexTest.php
+++ b/src/indexTest.php
@@ -466,4 +466,104 @@ final class IndexTest extends TestCase
 
         $this->assertEquals($result, $expected);
     }
+
+    public function testQBData8()
+    {
+        $QBdata = [
+            'condition' => 'AND',
+            'rules' => [
+                [
+                    'id' => 'name',
+                    'field' => 'name',
+                    'type' => 'string',
+                    'input' => 'text',
+                    'operator' => 'contains',
+                    'value' => '123'
+                ],
+                [
+                    'QB' => 'book',
+                    'condition' => 'or',
+                    'rules' => [
+                        [
+                            'id' => 'misc',
+                            'field' => 'misc',
+                            'type' => 'string',
+                            'input' => 'text',
+                            'operator' => 'is_null',
+                            'value' => null
+                        ],
+                        [
+                            'id' => 'type',
+                            'field' => 'type',
+                            'type' => 'string',
+                            'input' => 'checkbox',
+                            'operator' => 'in',
+                            'value' => ['book']
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $filters = [
+            'book' => function (
+                $group,
+                $rules,
+                $filters,
+                $options,
+                $postFilterUserFuncName
+            ) {
+                return [
+                    'must' => [
+                        ['terms' => ['_type' => ['book']]],
+                        [
+                            'bool' => call_user_func(
+                                $postFilterUserFuncName,
+                                $group,
+                                $rules,
+                                $filters,
+                                $options
+                            )
+                        ]
+                    ]
+                ];
+            }
+        ];
+
+        $options = ['onlyFields' => ['misc']];
+
+        $result = Boolbuilder\transform($QBdata, $filters, $options);
+
+        $expected = [
+            'bool' => [
+                'must' => [
+                    [
+                        'bool' => [
+                            'must' => [
+                                [
+                                    'bool' => [
+                                        'should' => [
+                                            [
+                                                'bool' => [
+                                                    'must_not' => [
+                                                        [
+                                                            'exists' => [
+                                                                'field' => 'misc'
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($result, $expected);
+    }
 }


### PR DESCRIPTION
Main update is to add `$option` parameter to main `Boolbuilder\transform` function to allow for filtering fields and operators.

Other small changes:

- Update namespace usage
- Simplify some function calls to be direct rather than via e.g., `call_user_func`
- Few more tests
- Small cleanup when iterating rules (i.e., do it once instead of twice)